### PR TITLE
fix: 온보딩 페이지 이후 카카오맵 로드 안되는 부분 수정

### DIFF
--- a/features/onboarding/components/result.tsx
+++ b/features/onboarding/components/result.tsx
@@ -15,7 +15,7 @@ export default function OnboardingResult() {
 
   const handleClick = () => {
     localStorage.setItem('onboardingCompleted', 'true')
-    router.push('/')
+    router.replace('/')
   }
 
   const { title, subtitle, type, image } = results[resultType as unknown as keyof ResultsType]


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

## 🔍 작업 내용

온보딩 페이지 이후 카카오맵 로드 안되는 부분 수정

## 🔧 변경 사항

- router.push에서 router.replace으로 변경

## 📸 스크린샷 (권장)

> 수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 🙏 리뷰 참고 (선택 사항)

> 개발 과정에서 다른 분들의 의견이 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요.

## 📄 기타 (선택 사항)

> 그 외 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
